### PR TITLE
Add link to live in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@
 
  HTML & CSS
 
+## Live Demo
+
+https://ciraganenicole.github.io/Portfolio/
 
 ### Prerequisites
 - Git/Github


### PR DESCRIPTION
In this pull request I:
- Deploy my portfolio to GitHub pages
- Add a link to the live demo in the README file